### PR TITLE
Basic work that handles most tests if a mongod is being run as a service

### DIFF
--- a/ssh-test-setup-ubuntu/Vagrantfile
+++ b/ssh-test-setup-ubuntu/Vagrantfile
@@ -86,7 +86,7 @@ Vagrant.configure("2") do |config|
       end
     end
     #tester.vm.provision "file",  source: "init-replicaset.js", destination: "init-replicaset.js"
-    tester.vm.provision "shell", inline: "sudo apt-get install gnupg"
+    tester.vm.provision "shell", inline: "sudo apt-get install -y gnupg"
     tester.vm.provision "shell", inline: "wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -"
     tester.vm.provision "shell", inline: "echo \"deb [ arch=amd64,arm64,s390x ] http://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/4.2 multiverse\" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list"
     tester.vm.provision "shell", inline: "sudo apt update"

--- a/ssh-test-setup-ubuntu/Vagrantfile
+++ b/ssh-test-setup-ubuntu/Vagrantfile
@@ -63,6 +63,8 @@ Vagrant.configure("2") do |config|
       node.vm.provider "virtualbox" do |vb|
         vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "1024"]
       end
+      node.vm.provision "shell", inline: "sudo sed -i 's/bindIp: 127.0.0.1/bindIpAll: true/' /etc/mongod.conf"
+      node.vm.provision 'shell', inline: "sudo sed -i 's/port: 27017/port: 27107/' /etc/mongod.conf"
       node.vm.provision "shell", inline: 'sudo systemctl disable mongod'
       node.vm.provision :reload
       node.vm.provision "shell", inline: '$HOME/start-mongod-replset-node.sh', privileged: false

--- a/ssh-test-setup/Vagrantfile
+++ b/ssh-test-setup/Vagrantfile
@@ -59,6 +59,8 @@ Vagrant.configure("2") do |config|
       SSHD_CONFIG
       node.vm.provision "shell", inline: "[ -d /home/vagrant/.ssh/ ] || mkdir /home/vagrant/.ssh", privileged: false
       node.vm.provision "shell", inline: "echo #{insecure_ssh_pub_key} >> /home/vagrant/.ssh/authorized_keys", privileged: false
+      node.vm.provision "shell", inline: "sudo sed -i 's/bindIp: 127.0.0.1/bindIpAll: true/' /etc/mongod.conf"
+      node.vm.provision 'shell', inline: "sudo sed -i 's/port: 27017/port: 27107/' /etc/mongod.conf"
       node.vm.provision "shell", inline: 'sudo systemctl stop mongod && sudo systemctl disable mongod'
       node.vm.provider "virtualbox" do |vb|
         vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "1024"]

--- a/ssh-test-setup/Vagrantfile
+++ b/ssh-test-setup/Vagrantfile
@@ -117,11 +117,9 @@ Vagrant.configure("2") do |config|
   config.vm.define "rs-3" do |rs_node|
     rs_node.vm.provision 'shell', inline: 'mongo mongodb://localhost:27017 init-replicaset.js', privileged: false
     rs_node.vm.provision 'shell', inline: 'mongo mongodb://localhost:28017 --ssl --sslCAFile tls/root.crt init-replicaset-ssl.js', privileged: false
-    #rs_node.vm.provision 'shell', inline: 'mongo mongodb://localhost:29017 --ssl --sslCAFile tls/root.crt init-replicaset-x509.js', privileged: false
     rs_node.vm.provision 'shell', inline: 'mongo mongodb://localhost:29017 init-replicaset-x509.js', privileged: false
     rs_node.vm.provision 'shell', inline: 'mongo mongodb://rs1.mongodb.test:27017,rs3.mongodb.test:27017/admin?replicaSet=replTest create-test-user.js', privileged: false
     rs_node.vm.provision 'shell', inline: 'mongo mongodb://rs1.mongodb.test:28017,rs3.mongodb.test:28017/admin?replicaSet=replTestTLS --ssl --sslCAFile tls/root.crt create-test-user.js', privileged: false
-    #rs_node.vm.provision 'shell', inline: 'mongo mongodb://rs1.mongodb.test:29017,rs3.mongodb.test:29017/admin?replicaSet=replTestX509 --ssl --sslCAFile tls/root.crt create-test-user-x509.js', privileged: false
     rs_node.vm.provision 'shell', inline: 'mongo mongodb://rs1.mongodb.test:29017,rs3.mongodb.test:29017/admin?replicaSet=replTestX509 create-test-user-x509.js', privileged: false
   end
 

--- a/tester-core/project.clj
+++ b/tester-core/project.clj
@@ -9,7 +9,7 @@
   :dependencies [[org.clojure/clojure           "1.10.0"]
                  [org.mongodb/mongodb-driver-sync "3.12.6"]
                  [clojurewerkz/urly             "1.0.0"]
-                 [com.taoensso/timbre           "4.10.0"] ;; Mainly used to get a chance to deal with the chatty Java driver
+                 [com.taoensso/timbre           "5.1.0"] ;; Mainly used to get a chance to deal with the chatty Java driver
                  [com.fzakaria/slf4j-timbre     "0.3.14"] ;; Attempt to send all log output through timbre
                  [org.slf4j/jul-to-slf4j        "1.7.14"]
                  ;;[org.clojure/tools.trace       "0.7.10"]

--- a/tester-core/src/tester_core/basic_functions.clj
+++ b/tester-core/src/tester_core/basic_functions.clj
@@ -16,8 +16,7 @@
 
 (defn start-mongo-process
   [uri mongo-parameters]
-  ;;(println "\nAttempting to start mongod with parameters\n" uri mongo-parameters)
-  ;;(println (type mongo-parameters))
+  (timbre/debug "Attempting to start mongo process at " uri " with parameters "  mongo-parameters)
   (if (is-mongod-process? mongo-parameters)
     (start-mongod-process uri mongo-parameters)
     (start-mongos-process uri mongo-parameters)))
@@ -49,7 +48,7 @@
   [uri & { :keys [user pwd ssl root-ca client-cert auth-mechanism] :or { user nil pwd nil ssl false root-ca nil client-cert nil auth-mechanism nil}}]
   (let [primary (get (get-rs-primary uri :user user :pwd pwd :ssl ssl :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism) :name)
         ssl-enabled (or ssl (.contains uri "ssl=true"))]
-    ;;(println "Trying to step down primary " primary " on replica set " uri ", root-ca " root-ca)
+    (timbre/debug "Trying to step down primary " primary " on replica set " uri ", root-ca " root-ca)
     (run-replset-stepdown (make-mongo-uri primary) :user user :pwd pwd :ssl ssl-enabled :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism)))
 
 (defn start-rs-nodes

--- a/tester-core/src/tester_core/core.clj
+++ b/tester-core/src/tester_core/core.clj
@@ -1,4 +1,5 @@
 (ns tester-core.core
+  (:require   [taoensso.timbre :as timbre :ref [log trace debug info warn error fatel report logf tracef debugf infof warnf errorf fatalf reportf spy getenv]])
   (:gen-class :main true))
 
 (load "helpers")

--- a/tester-core/src/tester_core/helpers.clj
+++ b/tester-core/src/tester_core/helpers.clj
@@ -23,7 +23,7 @@
 
 ;; Local helper functions, not exposed to other namespaces
 
-(defn- run-server-status
+(defn run-server-status
   [uri & { :keys [ user pwd ssl root-ca client-cert auth-mechanism ] :or { user nil pwd nil ssl false root-ca nil client-cert nil auth-mechanism nil} } ]
   (let [conn          (if (= (type uri) String) (md/mdb-connect uri :user user :pwd pwd :ssl ssl :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism) uri)
         server-status (md/mdb-admin-command conn { :serverStatus 1 })]

--- a/tester-core/src/tester_core/mini_driver.clj
+++ b/tester-core/src/tester_core/mini_driver.clj
@@ -222,7 +222,7 @@
              ;; (let [converted (pcv/from-bson-document result true)]
              ;;   (println "Converted result is " converted)
              ;;   converted)))
-          (do (println "Received MongoCommandException " e)
+          (do ;;(println "Received MongoCommandException " e)
               (throw e)))))))
 
 (defn mdb-admin-command

--- a/tester-core/src/tester_core/sys_helpers.clj
+++ b/tester-core/src/tester_core/sys_helpers.clj
@@ -1,7 +1,14 @@
 (ns tester-core.sys-helpers
   (:require [clojure.java.shell :refer [sh]]
             [clojure.string :as str :refer [join trim-newline]]
-            [clj-ssh.ssh :as ssh :refer :all]))
+            [clj-ssh.ssh :as ssh :refer :all]
+            [taoensso.timbre :as timbre :refer [log trace debug info warn error fatal]]))
+
+(defn- build-cmd-line-string
+  [cmdline]
+  (if (sequential? cmdline)
+    (str/join " " cmdline)
+    cmdline))
 
 ;;
 ;; SSH-based test helpers
@@ -9,24 +16,36 @@
 (defn run-remote-ssh-command
   "Execute a command described by cmdline on the remote server 'server'"
   [server cmdline]
-  ;;(println "\nAttempting to run ssh command " cmdline "\n")
+  (timbre/debug "Attempting to run ssh command " cmdline " on server " server)
+  (timbre/debug "run-remote-ssh-command: type of cmdline is " (type cmdline))
   (let [agent   (ssh/ssh-agent {})
         session (ssh/session agent server {:strict-host-key-checking :no})]
     (ssh/with-connection session
-      (let [result (ssh/ssh session { :cmd cmdline })]
-        result))))
+      (ssh/ssh session { :cmd (build-cmd-line-string cmdline) }))))
 
+
+(defn- is-local-machine?
+  [hostname]
+  ;; TODO - deal with hostnames that are FQDN hostnames, even for localhost
+  (if (= hostname "localhost")
+    true
+    (let [local-hostname (.getHostName (java.net.InetAddress/getLocalHost))]
+      (= hostname local-hostname))))
 
 (defn get-os-type
   "Retrieve the OS of the current system"
   ([]
    (System/getProperty "os.name"))
   ([hostname]
-  (let [agent   (ssh/ssh-agent {})
-        session (ssh/session agent hostname {:strict-host-key-checking :no})]
-    (ssh/with-connection session
-      (let [result (ssh/ssh session { :cmd "uname" })]
-        (str/trim-newline (:out result)))))))
+   (if (is-local-machine? hostname)
+     (get-os-type)
+     (let [result (run-remote-ssh-command hostname "uname")]
+       (str/trim-newline (:out result))))))
+     ;; (let [agent   (ssh/ssh-agent {})
+     ;;       session (ssh/session agent hostname {:strict-host-key-checking :no})]
+     ;;   (ssh/with-connection session
+     ;;     (let [result (ssh/ssh session { :cmd "uname" })]
+     ;;       (str/trim-newline (:out result)))))))) 
    
 
 (defn- parse-ps-output
@@ -46,8 +65,11 @@
    (let [proc-list (sh "ps" "ax" "-o" "pid=" "-o" "command=")]
      (doall (map #(parse-ps-output %) (clojure.string/split-lines (get proc-list :out))))))
   ([server]
-   (let [proc-list (run-remote-ssh-command server "ps ax -o pid= -o command=")]
-     (doall (map #(parse-ps-output %) (clojure.string/split-lines (get proc-list :out)))))))
+   (if (is-local-machine? server)
+     (get-process-list-bsd)
+     (let [proc-list (run-remote-ssh-command server "ps ax -o pid= -o command=")]
+       ;;(println "Proc list for server " server " is " proc-list)
+       (doall (map #(parse-ps-output %) (clojure.string/split-lines (get proc-list :out))))))))
   
    
 ;; NOTE - this code can be improved by using the ProcessHandle API on Java 9+
@@ -65,15 +87,13 @@
 (defn- check-if-service-linux
   [hostname pid]
   (let [cmdline (str/join ["systemctl status " (str pid) " | grep '\\.service'"])]
-    (if (= hostname "localhost")
+    (timbre/trace "Checking if service for hostname " hostname)
+    (if (is-local-machine? hostname)
       nil
-      (let [agent   (ssh/ssh-agent {})
-            session (ssh/session agent hostname {:strict-host-key-checking :no})]
-        (ssh/with-connection session
-          (= (:exit (ssh/ssh session { :cmd cmdline })) 0))))))
+      (= (:exit (run-remote-ssh-command hostname cmdline)) 0))))
   
 
-(defn check-if-service
+(defn is-service?
   "Checks if a process was started via a service. Works on most supported Linux versions
    with the exception of Amazon Linux 1"
   [hostname pid]
@@ -81,3 +101,4 @@
     (cond
       (= os "Linux")  (check-if-service-linux hostname pid)
       :else nil)))
+

--- a/tester-core/src/tester_core/test_functions.clj
+++ b/tester-core/src/tester_core/test_functions.clj
@@ -31,7 +31,8 @@
   (let [ssl-enabled  (or ssl (.contains rs-uri "ssl=true"))
         stop-members (doall (map #(make-mongo-uri (get % :name)) (get-random-members rs-uri member-num :user user :pwd pwd :ssl ssl-enabled :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism)))
         restart-info (doall (map #(stop-mongo-process % :user user :pwd pwd :ssl ssl-enabled :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism) stop-members))]
-    ;;(println "\nRestart info" restart-info)
+    (timbre/debug "partial-stop-rs: restart info is " (str restart-info))
+    ;;(flush)
     (fn [] (if (seq? restart-info)
              (doall (map #(start-mongo-process (get % :uri) (get % :cmd-line)) restart-info))
              (start-mongo-process (get restart-info :uri) (get restart-info :cmd-line))))))

--- a/tester-core/src/tester_core/test_functions.clj
+++ b/tester-core/src/tester_core/test_functions.clj
@@ -30,12 +30,16 @@
   [rs-uri member-num & { :keys [ user pwd ssl root-ca client-cert auth-mechanism ] :or { user nil pwd nil ssl false root-ca nil client-cert nil auth-mechanism nil } }]
   (let [ssl-enabled  (or ssl (.contains rs-uri "ssl=true"))
         stop-members (doall (map #(make-mongo-uri (get % :name)) (get-random-members rs-uri member-num :user user :pwd pwd :ssl ssl-enabled :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism)))
-        restart-info (doall (map #(stop-mongo-process % :user user :pwd pwd :ssl ssl-enabled :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism) stop-members))]
-    (timbre/debug "partial-stop-rs: restart info is " (str restart-info))
+        restart-info (into () (doall (map #(stop-mongo-process % :user user :pwd pwd :ssl ssl-enabled :root-ca root-ca :client-cert client-cert :auth-mechanism auth-mechanism) stop-members)))]
+    (timbre/debug "partial-stop-rs: restart info is " restart-info)
     ;;(flush)
-    (fn [] (if (seq? restart-info)
-             (doall (map #(start-mongo-process (get % :uri) (get % :cmd-line)) restart-info))
-             (start-mongo-process (get restart-info :uri) (get restart-info :cmd-line))))))
+    (fn [] (do (timbre/debug "Attempting to execute restart function with info " restart-info)
+               (if (seq? restart-info)
+                 (doall (map (fn[info]
+                               (do (timbre/debug "Calling restart function with list of  parameters " info)
+                                   (start-mongo-process (get info :uri) (get info :cmd-line)))) restart-info))
+                 (do (timbre/debug "Calling restart function with parameters " restart-info)
+                     (start-mongo-process (get restart-info :uri) (get restart-info :cmd-line))))))))
 
 (defn make-rs-degraded
   "Simulate a degraded but fully functional RS (majority of nodes still available"

--- a/tester-core/test/tester_core/core_test.clj
+++ b/tester-core/test/tester_core/core_test.clj
@@ -3,7 +3,7 @@
             [tester-core.core :refer :all]
             [taoensso.timbre :as timbre]))
 
-(timbre/merge-config!
-  {:level :warn
-   :ns-blacklist [] #_["org.mongodb.*"]})
+;; (timbre/merge-config!
+;;   {:level :warn
+;;    :ns-blacklist [] #_["org.mongodb.*"]})
 

--- a/tester-core/test/tester_core/core_test_replicaset.clj
+++ b/tester-core/test/tester_core/core_test_replicaset.clj
@@ -27,6 +27,7 @@
   (is (= 0 (num-running-mongo-processes))))
 
 (use-fixtures :each wrap-rs-tests)
+(use-fixtures :once setup-logging-fixture)
 
 (deftest test-is-mongos-process
   (testing "Check if we're running against a mongos process - should fail as we're running mongod"
@@ -47,12 +48,12 @@
           primary      (get (get-rs-primary conn) :name)
           secondaries  (sort (map #(get % :name) (get-rs-secondaries conn)))]
       ;;(println "Local primary is " primary)
-      (println "Topology - secondaries are " secondaries)
+      ;;(timbre/debug "Topology - secondaries are " secondaries)
       (is (= 5 (num-active-rs-members conn)))
       (md/mdb-disconnect conn)
       (is (some? (or (re-matches #"localhost:2701[7-9]" primary) (re-matches #"localhost:2702[1-2]" primary))))
       (is (not (some #{primary} secondaries)))
-      (println "Secondaries are " secondaries)
+      ;;(timbre/debug "Secondaries are " secondaries)
       (is (= 4 (count secondaries))))))
 
 

--- a/tester-core/test/tester_core/core_test_sharded.clj
+++ b/tester-core/test/tester_core/core_test_sharded.clj
@@ -40,6 +40,7 @@
   (wait-mongo-shutdown 40))
 
 (use-fixtures :each wrap-sharded-tests)
+(use-fixtures :once setup-logging-fixture)
 
 (deftest test-get-config-servers-uri
   (testing "Try to retrieve the URIs of the config servers"

--- a/tester-core/test/tester_core/ssh_test_replicaset.clj
+++ b/tester-core/test/tester_core/ssh_test_replicaset.clj
@@ -8,42 +8,23 @@
 (ns tester-core.ssh-test-replicaset
   (:require [clojure.test :refer :all]
             [tester-core.core :refer :all]
-            [tester-core.test-helpers :refer :all]))
-
-(defn- start-remote-mongods
-  [servers]
-  (ssh-apply-command-to-rs-servers "mongod -f mongod-ssh-rs.conf" servers))
-
-(defn- stop-remote-mongods
-  [servers]
-  (ssh-apply-command-to-rs-servers "pkill mongod" servers))
-
-;; (defn- wait-mongo-shutdown
-;;   "Wait until we have no further MongoDB processes running"
-;;   [server-list max-retries]
-;;   (let [retries (atom 0)]
-;;     (while (> (num-running-mongo-processes server-list) 0)
-;;       ;;(println "Waiting for test processes to shut down")
-;;       (if (< @retries max-retries)
-;;         (do ;;(println "Waiting for remote mongo process to shut down, attempt " @retries)
-;;             (Thread/sleep 500)
-;;             (reset! retries (inc @retries)))
-;;         (println "Unable to shut down remaining mongod processes")))))
-
+            [tester-core.test-helpers :refer :all]
+            [taoensso.timbre :as timbre :refer [debug error]]))
 
 (defn- ssh-test-fixture
   [f]
   (let [servers ["rs1.mongodb.test" "rs2.mongodb.test" "rs3.mongodb.test"]]
     (is (= 0 (num-running-mongo-processes servers)))
-    (start-remote-mongods servers)
+    (ssh-apply-command-to-rs-servers "mongod -f mongod-ssh-rs.conf" servers)
     (Thread/sleep 1500)
     (if (wait-test-rs-ready "mongodb://rs1.mongodb.test:27017,rs2.mongodb.test:27017,rs3.mongodb.test:27017/?replicaSet=replTest&connectTimeoutMS=1000" 3 17 :user "admin" :pwd "pw99")
       (f)
-      (println "Test replica set not ready in time"))
-    (stop-remote-mongods servers)
+      (timbre/error "Test replica set not ready in time"))
+    (ssh-apply-command-to-rs-servers "pkill mongod" servers)
     (wait-mongo-shutdown servers 20)))
 
 (use-fixtures :each ssh-test-fixture)
+(use-fixtures :once setup-logging-fixture)
 
 (deftest test-is-mongos-process
   (testing "Check if we're running against a mongos process - should fail as we're running mongod"

--- a/tester-core/test/tester_core/ssh_test_replicaset_x509.clj
+++ b/tester-core/test/tester_core/ssh_test_replicaset_x509.clj
@@ -8,29 +8,23 @@
   (:require [clojure.test :refer :all]
             [tester-core.core :refer :all]
             [tester-core.test-helpers :refer :all]
-            [tester-core.mini-driver :as md :refer :all]))
-
-(defn- start-remote-mongods
-  [servers]
-  (ssh-apply-command-to-rs-servers "mongod -f mongod-ssh-x509.conf" servers))
-
-(defn- stop-remote-mongods
-  [servers]
-  (ssh-apply-command-to-rs-servers "pkill mongod" servers))
+            [tester-core.mini-driver :as md :refer :all]
+            [taoensso.timbre :as timbre :refer [debug error]]))
 
 (defn- ssh-test-fixture
   [f]
   (let [servers ["rs1.mongodb.test" "rs2.mongodb.test" "rs3.mongodb.test"]]
     (is (= 0 (num-running-mongo-processes servers)))
-    (start-remote-mongods servers)
+    (ssh-apply-command-to-rs-servers "mongod -f mongod-ssh-x509.conf" servers)
     (Thread/sleep 1500)
     (if (wait-test-rs-ready "mongodb://rs1.mongodb.test:29017,rs2.mongodb.test:29017,rs3.mongodb.test:29017/?replicaSet=replTestX509&connectTimeoutMS=1000&ssl=true" 3 17 :client-cert "../../../tls/user-cert.pem" :ssl true :root-ca "../../../tls/root.crt" :auth-mechanism :mongodb-x509)
       (f)
-      (println "Test replica set not ready in time"))
-    (stop-remote-mongods servers)
+      (timbre/error "Test replica set not ready in time"))
+    (ssh-apply-command-to-rs-servers "pkill mongod" servers)    
     (wait-mongo-shutdown servers 20)))
 
 (use-fixtures :each ssh-test-fixture)
+(use-fixtures :once setup-logging-fixture)
 
 (deftest test-is-mongos-process
   (testing "Check if we're running against a mongos process - should fail as we're running mongod"

--- a/tester-core/test/tester_core/ssh_test_service_replicaset.clj
+++ b/tester-core/test/tester_core/ssh_test_service_replicaset.clj
@@ -1,0 +1,68 @@
+(ns tester-core.ssh-test-service-replicaset
+  (:require [clojure.test :refer :all]
+            [tester-core.core :refer :all]
+            [tester-core.test-helpers :refer :all]
+            [taoensso.timbre :as timbre :refer [debug error]]))
+
+(defn- ssh-test-fixture
+  [f]
+  (let [servers ["rs1.mongodb.test" "rs2.mongodb.test" "rs3.mongodb.test"]]
+    (is (= 0 (num-running-mongo-processes servers)))
+    (ssh-apply-command-to-rs-servers "sudo systemctl start mongod" servers)
+    (Thread/sleep 1500)
+    (if (wait-test-rs-ready "mongodb://rs1.mongodb.test:27107,rs2.mongodb.test:27107,rs3.mongodb.test:27107/?replicaSet=replTestService&connectTimeoutMS=1000" 3 17)
+      (f)
+      (timbre/error "Test replica set not ready in time"))
+    (ssh-apply-command-to-rs-servers "sudo systemctl stop mongod" servers)
+    (wait-mongo-shutdown servers 20)))
+
+(use-fixtures :each ssh-test-fixture)
+(use-fixtures :once setup-logging-fixture)
+
+(deftest test-get-rs-topology
+  (testing "Check that we retrieve the correct primary and secondaries from the replset status"
+    (let [primary      (get (get-rs-primary "mongodb://rs1.mongodb.test:27107") :name)
+          secondaries  (sort (map #(get % :name) (get-rs-secondaries "mongodb://rs1.mongodb.test:27107")))]
+      (timbre/debug "Remote primary is " primary)
+      (timbre/debug "Remote secondaries are " secondaries)
+      (is (not (nil? (re-matches #"rs[1-3].mongodb.test:27107" primary))))
+      (is (not (some #{primary} secondaries)))
+      (is (= (count secondaries) 2)))))
+
+(deftest test-rs-stepdown
+  (testing "Check that stepping down the primary on an RS works"
+    (let [rs-uri "mongodb://rs1.mongodb.test:27107,rs2.mongodb.test:27107,rs3.mongodb.test:27107/?replicaSet=replTestService"
+          original-primary (get (get-rs-primary rs-uri) :name)]
+      (is original-primary)
+      (timbre/debug "Current primary is " original-primary)
+      (trigger-election rs-uri)
+      (Thread/sleep 11000)
+      (is (not (= (get (get-rs-primary rs-uri) :name) original-primary))))))
+
+
+(deftest test-remote-degrade-rs
+  (testing "Check that we can make a remote RS degraded (requires auth on remote RS"
+    (let [rs-uri "mongodb://rs1.mongodb.test:27107,rs2.mongodb.test:27107,rs3.mongodb.test:27107/?replicaSet=replTestService"
+          restart-cmd (make-rs-degraded rs-uri) ]
+      (is (not (nil? restart-cmd)))
+      (Thread/sleep 30000)
+      (is (replicaset-degraded? rs-uri))
+      (Thread/sleep 1000)
+      (restart-cmd)
+      (Thread/sleep 8000)
+      (is (not (replicaset-degraded? rs-uri))))))
+    
+(deftest test-remote-read-only-rs
+  (testing "Check that we are able to successfully make a replica set read only
+            and restore it afterwards"
+    (let [rs-uri "mongodb://rs1.mongodb.test:27107,rs2.mongodb.test:27107,rs3.mongodb.test:27107/?replicaSet=replTestService"
+          restart-cmd (make-rs-read-only rs-uri)]
+      (is (not (nil? restart-cmd)))
+      (Thread/sleep 20000)
+      (is (= (num-active-rs-members rs-uri) 1))
+      (is (replica-set-read-only? rs-uri))
+      (Thread/sleep 1000)
+      (restart-cmd)
+      (Thread/sleep 5000)
+      (is (= (num-active-rs-members rs-uri) 3))
+      )))

--- a/tester-core/test/tester_core/sys_helpers_test.clj
+++ b/tester-core/test/tester_core/sys_helpers_test.clj
@@ -1,5 +1,6 @@
 (ns tester-core.sys-helpers-test
   (:require [tester-core.sys-helpers :refer :all]
+            [tester-core.core :refer [run-server-status]]
             [clojure.test :refer :all]
             [clojure.pprint :refer :all]))
 
@@ -16,3 +17,15 @@
   (testing "Check the result of get-os-type"
     (let [os-type (get-os-type)]
       (is (or (= os-type "Linux") (= os-type "Mac OS X") (= os-type "Windows"))))))
+
+(deftest test-get-os-type-remote
+  (testing "Check the result of remote get-os-type"
+    (let [os-type (get-os-type "rs1")]
+      (is (= os-type "Linux")))))
+
+(deftest test-is-service
+  (testing "Check if remote MongoDB was started as a service or not"
+    (let [pid (:pid (run-server-status "mongodb://rs1.mongodb.test:27017" :user "admin" :pwd "pw99"))
+          result (check-if-service "rs1.mongodb.test" pid)]
+      (is (= result false)))))
+      

--- a/tester-core/test/tester_core/sys_helpers_test.clj
+++ b/tester-core/test/tester_core/sys_helpers_test.clj
@@ -1,5 +1,6 @@
 (ns tester-core.sys-helpers-test
   (:require [tester-core.sys-helpers :refer :all]
+            [tester-core.test-helpers :refer [ssh-apply-command-to-rs-servers]]
             [tester-core.core :refer [run-server-status]]
             [clojure.test :refer :all]
             [clojure.pprint :refer :all]))
@@ -20,12 +21,22 @@
 
 (deftest test-get-os-type-remote
   (testing "Check the result of remote get-os-type"
-    (let [os-type (get-os-type "rs1")]
+    (let [os-type (get-os-type "rs1.mongodb.test")]
       (is (= os-type "Linux")))))
 
-(deftest test-is-service
+(deftest test-is-not-service
   (testing "Check if remote MongoDB was started as a service or not"
+    (ssh-apply-command-to-rs-servers "./start-mongod-replset-node.sh" (list "rs1.mongodb.test"))
     (let [pid (:pid (run-server-status "mongodb://rs1.mongodb.test:27017" :user "admin" :pwd "pw99"))
           result (check-if-service "rs1.mongodb.test" pid)]
-      (is (= result false)))))
-      
+      (is (= result false)))
+    (ssh-apply-command-to-rs-servers "pkill mongod" (list "rs1.mongodb.test"))))
+
+
+(deftest test-is-service
+  (testing "Make sure we correcty identify a mongod that was started as a service"
+    (ssh-apply-command-to-rs-servers "sudo systemctl start mongod" (list "rs1.mongodb.test"))
+    (let [pid (:pid (run-server-status "mongodb://rs1.mongodb.test:27107"))
+          result (check-if-service "rs1.mongodb.test" pid)]
+      (is (= result true)))
+    (ssh-apply-command-to-rs-servers "sudo systemctl stop mongod" (list "rs1.mongodb.test"))))

--- a/tester-core/test/tester_core/sys_helpers_test.clj
+++ b/tester-core/test/tester_core/sys_helpers_test.clj
@@ -7,7 +7,6 @@
 
 (deftest test-get-process-list
   (testing "Check that we can get the list of processes"
-                                        ;(doall (map #(pprint %) get-process-list))))
     (let [proc-list (get-process-list)]      
       (not (nil? proc-list))
       (is (> (count proc-list) 1))

--- a/tester-core/test/tester_core/sys_helpers_test.clj
+++ b/tester-core/test/tester_core/sys_helpers_test.clj
@@ -27,7 +27,7 @@
   (testing "Check if remote MongoDB was started as a service or not"
     (ssh-apply-command-to-rs-servers "./start-mongod-replset-node.sh" (list "rs1.mongodb.test"))
     (let [pid (:pid (run-server-status "mongodb://rs1.mongodb.test:27017" :user "admin" :pwd "pw99"))
-          result (check-if-service "rs1.mongodb.test" pid)]
+          result (is-service? "rs1.mongodb.test" pid)]
       (is (= result false)))
     (ssh-apply-command-to-rs-servers "pkill mongod" (list "rs1.mongodb.test"))))
 
@@ -36,6 +36,6 @@
   (testing "Make sure we correcty identify a mongod that was started as a service"
     (ssh-apply-command-to-rs-servers "sudo systemctl start mongod" (list "rs1.mongodb.test"))
     (let [pid (:pid (run-server-status "mongodb://rs1.mongodb.test:27107"))
-          result (check-if-service "rs1.mongodb.test" pid)]
+          result (is-service? "rs1.mongodb.test" pid)]
       (is (= result true)))
     (ssh-apply-command-to-rs-servers "sudo systemctl stop mongod" (list "rs1.mongodb.test"))))

--- a/tester-core/test/tester_core/test_helper_functions.clj
+++ b/tester-core/test/tester_core/test_helper_functions.clj
@@ -1,0 +1,17 @@
+(ns tester-core.test-helper-functions
+  (:require [clojure.test :refer :all]
+            [tester-core.core :refer :all]
+            [tester-core.test-helpers :refer :all]
+            [taoensso.timbre :as timbre :refer [debug error]]))
+
+
+(deftest test-is-mongodb-uri
+  (testing "Check that is-mongodb-uri? returns the expected values"
+    (is (is-mongodb-uri? "mongodb://localhost:27107/"))
+    (is (not (is-mongodb-uri? "http://mongodb.com")))))
+
+(deftest test-is-local-process
+  (testing "Check that is-local-process? returns the expected values"
+    (is (is-local-process? "mongodb://localhost"))
+    (is (is-local-process? "localhost"))
+    (is (not (is-local-process? "mongodb://rs1.mongodb.test")))))

--- a/tester-core/test/tester_core/test_helpers.clj
+++ b/tester-core/test/tester_core/test_helpers.clj
@@ -1,10 +1,17 @@
 (ns tester-core.test-helpers
   (:require [tester-core.core :refer :all]
-            [tester-core.sys-helpers :refer :all]
+            [tester-core.sys-helpers :as sys :refer :all]
             [tester-core.mini-driver :as md :refer :all]
             [clj-ssh.ssh :as ssh :refer :all]
-            [clojure.set :refer :all])
+            [clojure.set :refer :all]
+            [taoensso.timbre :as timbre :refer :all])
   (:import  [com.mongodb ReadPreference]))
+
+(defn setup-logging-fixture
+  [f]
+  (timbre/debug "setting up logging")
+  (timbre/merge-config! {:min-level `[[#{"org.mongodb.*"} :error] [#{"*"} :warn]]})
+  (f))
 
 
 (defn available-mongods
@@ -152,4 +159,6 @@
 
 (defn ssh-apply-command-to-rs-servers
   [cmd servers]
-  (doall (map #(run-remote-ssh-command % cmd) servers)))
+  (timbre/debug "ssh-apply-command-to-rs-servers: trying to apply command " cmd " of type " (type cmd) " to servers " servers)
+  (doall (map #(sys/run-remote-ssh-command % cmd) servers)))
+

--- a/tester-core/test/tester_core/test_helpers.clj
+++ b/tester-core/test/tester_core/test_helpers.clj
@@ -13,6 +13,12 @@
   (timbre/merge-config! {:min-level `[[#{"org.mongodb.*"} :error] [#{"*"} :warn]]})
   (f))
 
+(defn setup-logging-fixture-debug
+  [f]
+  (timbre/debug "setting up logging")
+  (timbre/merge-config! {:min-level `[[#{"org.mongodb.*"} :error] [#{"clj-ssh.*"} :warn] [#{"*"} :debug]]})
+  (f))
+
 
 (defn available-mongods
   "Try to create a list of available mongods on the current machine"


### PR DESCRIPTION
Currently only works on Linux with systemd based distros.

Adds code to check if a mongo(d) process is started as a service and tries to control it via the service interface rather than by manually starting/stopping it.